### PR TITLE
3주차 버그수정 및 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     implementation "com.google.dagger:hilt-android:2.28-alpha"
     implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha01'
     implementation 'com.google.firebase:firebase-database:19.2.1'
+    implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
+    implementation 'io.reactivex.rxjava3:rxjava:3.1.2'
     annotationProcessor 'androidx.hilt:hilt-compiler:1.0.0-alpha01'
     kapt "com.google.dagger:hilt-android-compiler:2.28-alpha"
     testImplementation 'junit:junit:4.+'

--- a/app/src/main/java/kr/co/project/zeroid/englishdictionary/singleton/SingletonVocaMap.java
+++ b/app/src/main/java/kr/co/project/zeroid/englishdictionary/singleton/SingletonVocaMap.java
@@ -1,0 +1,43 @@
+package kr.co.project.zeroid.englishdictionary.singleton;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseReference;
+import com.google.firebase.database.FirebaseDatabase;
+
+import java.util.HashMap;
+
+import androidx.annotation.NonNull;
+
+public class SingletonVocaMap {
+    private static HashMap<String,HashMap<String,String>> singletonVocaMap = null;
+    private static FirebaseDatabase database = FirebaseDatabase.getInstance();
+    private SingletonVocaMap() { }
+    public static synchronized HashMap<String,HashMap<String,String>> getInstance(Context context) {
+        if (singletonVocaMap == null) {
+            HashMap<String,HashMap<String,String>> vocaMap = new HashMap<String, HashMap<String,String>>();
+            singletonVocaMap = vocaMap;
+        }
+        return singletonVocaMap;
+    }
+
+    public static void readToFirebaseRealtimeDatabase(DatabaseReference databaseReference) {
+        databaseReference.child("users").child(FirebaseAuth.getInstance().getUid()).get().addOnCompleteListener(new OnCompleteListener<DataSnapshot>() {
+            @Override
+            public void onComplete(@NonNull Task<DataSnapshot> task) {
+                if (!task.isSuccessful()) {
+                    Log.d("firebase", "Error getting data", task.getException());
+                    SingletonVocaMap.singletonVocaMap=null;
+                }
+                else {
+                    SingletonVocaMap.singletonVocaMap= (HashMap<String,HashMap<String,String>>)task.getResult().getValue();
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/res/layout/activity_add_voca.xml
+++ b/app/src/main/res/layout/activity_add_voca.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:layout_marginTop="30dp"
     tools:context=".addVoca.AddVocaActivity">
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:layout_marginTop="30dp">
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -52,4 +55,12 @@
         android:text="단어추가"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"/>
-</LinearLayout>
+    </LinearLayout>
+    <ProgressBar
+        android:id="@+id/addVocaProgressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_centerVertical="true"/>
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_add_voca.xml
+++ b/app/src/main/res/layout/activity_add_voca.xml
@@ -46,8 +46,7 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:layout_marginLeft="20dp"
-        android:layout_marginRight="20dp"
-        android:choiceMode="multipleChoice"/>
+        android:layout_marginRight="20dp" />
     <Button
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,7 +7,7 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="gray">#CCCCCC</color>
+<!--    <color name="gray">#CCCCCC</color>-->
     <color name="blue_button">#0085FF</color>
     <color name="gray">#AAA</color>
     <color name="red_title">#FF0000</color>


### PR DESCRIPTION
##이번주 할일
- [x] 한국어 검색시 여러개의 영단어중 하나만 체크하게 바꾸기
- [x] 단어검색시 비동기 통신
- [x] firebase 데이터 파싱
- [ ] 인터넷 여부 확인
- [x] 파이어베이스 데이터 순서 1,2,3 ... 순서로 바꾸기
- [x] startActivityForResult -> ActivityResultLauncher로 변경

1. 자동로그인이 된 상태에서 처음 앱을 켜면 DB에서 단어들을 불러옵니다.
2. 단어추가 창으로 넘어가면 DB의 단어를 반환해줍니다.
예외상황 : 여기서 처음 로그인하고 바로 단어추가 창으로 넘어가면 DB에서 단어를 불러오는 시간이 1초 정도 걸리기때문에 단어가 없다고 나올수 있습니다.
해결방법 : 불러오는시간이 있어서 이것도 비동기로 만들어서 나만의 단어장에 들어갈때 로딩창이 나오게 만들거나 아니면 나만의 단어장을 몇초있다가 나오게 하는 방법이 있을꺼 같습니다.
3. 단어추가하면 추가하고 단어를 다시 DB에서 받아옵니다.
4. 홈화면으로 갔다가 단어추가창으로 오면 단어가 추가된걸 볼수 있습니다.